### PR TITLE
feat: health endpoint now checks blockchain connection, additional logging

### DIFF
--- a/src/lib/block-emitter.ts
+++ b/src/lib/block-emitter.ts
@@ -20,8 +20,10 @@ export class BlockEmitter extends TypedEmitter<BlockEmitterEvents> {
   }
 
   handleBlock = async (blockNumber: number): Promise<void> => {
+    logger.debug(`handling block ${blockNumber}`)
     const { hash } = await this.provider.getBlock(blockNumber)
 
+    logger.debug(`block hash for block ${blockNumber} is ${hash}`)
     this.emit('block', {
       number: blockNumber,
       hash,

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,22 +50,23 @@ export const createApp = ({ rpcUrl, privateKey, bzzAddress }: AppConfig, logger:
 
   // Health, metrics, assets, default endpoints
   app.get('/health', async (_req, res) => {
-    res.sendStatus(200)
-  })
-
-  app.get('/readiness', async (_req, res) => {
     try {
       // Check we have connection to blockchain
-      await provider.getBlockNumber()
-
-      // Check blockEmitter has processed some block
-      if (blockEmitter.lastProcessedBlock === null) {
-        throw new Error('No processed blocks yet')
-      }
+      const blockNum = await provider.getBlockNumber()
+      await provider.getBlock(blockNum)
 
       res.sendStatus(200)
     } catch (err) {
       logger.error('readiness', err)
+      res.sendStatus(502)
+    }
+  })
+
+  app.get('/readiness', async (_req, res) => {
+    // Check blockEmitter has processed some block
+    if (blockEmitter.lastProcessedBlock === null) {
+      res.sendStatus(502)
+    } else {
       res.sendStatus(502)
     }
   })

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,7 +67,7 @@ export const createApp = ({ rpcUrl, privateKey, bzzAddress }: AppConfig, logger:
     if (blockEmitter.lastProcessedBlock === null) {
       res.sendStatus(502)
     } else {
-      res.sendStatus(502)
+      res.sendStatus(200)
     }
   })
 

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -18,9 +18,16 @@ afterAll(async () => {
 
 describe('GET /health', () => {
   it('should return 200 & OK', async () => {
+    await mineBlock()
     const res = await request(app).get(`/health`).expect(200)
 
     expect(res.text).toEqual('OK')
+  })
+
+  it('should return 502 & Bad Gateway with wrong RPC URL', async () => {
+    const res = await request(appWrongRpcUrl).get(`/health`).expect(502)
+
+    expect(res.text).toEqual('Bad Gateway')
   })
 })
 
@@ -30,11 +37,5 @@ describe('GET /readiness', () => {
     const res = await request(app).get(`/readiness`).expect(200)
 
     expect(res.text).toEqual('OK')
-  })
-
-  it('should return 502 & Bad Gateway with wrong RPC URL', async () => {
-    const res = await request(appWrongRpcUrl).get(`/readiness`).expect(502)
-
-    expect(res.text).toEqual('Bad Gateway')
   })
 })


### PR DESCRIPTION
Still seeing a bit of a criptic error which now however looks like the block emitter fails to retrieve block info
```
  |   | 2022-06-23 11:18:55 | time="2022-06-23T09:18:55.550Z" level="debug" msg="checking blocks 22801992 - 22806258"
  |   | 2022-06-23 11:18:55 | time="2022-06-23T09:18:55.546Z" level="debug" msg="Lock requested for the block emitter resource - 0 active, 0 waiting"
  |   | 2022-06-23 11:18:55 | time="2022-06-23T09:18:55.279Z" level="debug" msg="emitted new block 22806258"
  |   | 2022-06-23 11:18:55 | time="2022-06-23T09:18:55.273Z" level="debug" msg="checking blocks 22806258 - 22806258"
  |   | 2022-06-23 11:18:55 | time="2022-06-23T09:18:55.269Z" level="debug" msg="Lock requested for the block emitter resource - 0 active, 0 waiting"
  |   | 2022-06-23 11:18:55 | time="2022-06-23T09:18:55.200Z" level="error" msg="failed to check blocks:  Error\n    at BlockEmitter.handler (/app/dist/routes/faucet.js:43:27)\n    at BlockEmitter.emit (node:events:537:28)\n    at BlockEmitter.handleBlock (/app/dist/lib/block-emitter.js:16:18)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async BlockEmitter.handleBlocks (/app/dist/lib/block-emitter.js:32:17)\n    at async BlockEmitter.check (/app/dist/lib/block-emitter.js:39:17)"
  |   | 2022-06-23 11:18:55 | time="2022-06-23T09:18:55.194Z" level="debug" msg="checking blocks 22797494 - 22806258"
  |   | 2022-06-23 11:18:55 | time="2022-06-23T09:18:55.190Z" level="debug" msg="Lock requested for the block emitter resource - 0 active, 0 waiting"
  |   | 2022-06-23 11:18:54 | time="2022-06-23T09:18:54.029Z" level="info" msg="api access" duration="0.000000000" ip="::ffff:10.4.158.***" method="GET" size=111 status=200 uri="/health" user-agent="kube-probe/1.20+"
  |   | 2022-06-23 11:18:53 | time="2022-06-23T09:18:53.204Z" level="info" msg="api access" duration="0.000000000" ip="::ffff:10.4.3.***" method="GET" size=288 status=200 uri="/metrics" user-agent="Prometheus/2.34.0"
```